### PR TITLE
Make restart/shutdown/logout options interactive

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -29,19 +29,26 @@ function _sleep() {
 }
 
 function _restart() {
-	Util.spawn(['systemctl', 'reboot'])
+	// Util.spawn(['systemctl', 'reboot'])
+	// Util.spawn(['gnome-session-quit', '--reboot'])
+	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Reboot'])
 }
 
 function _shutdown() {
-	Util.spawn(['systemctl', 'poweroff', '-prompt'])
+	// Util.spawn(['systemctl', 'poweroff', '-prompt'])
+	// Util.spawn(['gnome-session-quit', '--power-off'])
+	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Shutdown'])
 }
 
 function _lockScreen() {
-	Util.spawn(['loginctl', 'lock-session'])
+	// Util.spawn(['loginctl', 'lock-session'])
+	Util.spawn(['dbus-send', '--type=method_call', '--dest=org.gnome.ScreenSaver', '/org/gnome/ScreenSaver', 'org.gnome.ScreenSaver.Lock'])
 }
 
 function _logOut() {
-	Util.spawn(['gnome-session-quit'])
+	// Util.spawn(['gnome-session-quit'])
+	// Util.spawn(['gnome-session-quit', '--logout'])
+	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Logout', 'uint32:0'])
 }
 
 function _appGrid() {
@@ -150,8 +157,8 @@ var MenuButton = GObject.registerClass(class LogoMenu_MenuButton extends PanelMe
 		if (poweroption_state) {
 			this.item12 = new PopupMenu.PopupSeparatorMenuItem()
 			this.item13 = new PopupMenu.PopupMenuItem(_('Sleep'))
-			this.item14 = new PopupMenu.PopupMenuItem(_('Restart'))
-			this.item15 = new PopupMenu.PopupMenuItem(_('Shut Down'))
+			this.item14 = new PopupMenu.PopupMenuItem(_('Restart...'))
+			this.item15 = new PopupMenu.PopupMenuItem(_('Shut Down...'))
 			this.item16 = new PopupMenu.PopupSeparatorMenuItem()
 			if (lockscreen_state) 
 				this.item17 = new PopupMenu.PopupMenuItem(_('Lock Screen'))

--- a/extension.js
+++ b/extension.js
@@ -29,25 +29,18 @@ function _sleep() {
 }
 
 function _restart() {
-	// Util.spawn(['systemctl', 'reboot'])
-	// Util.spawn(['gnome-session-quit', '--reboot'])
 	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Reboot'])
 }
 
 function _shutdown() {
-	// Util.spawn(['systemctl', 'poweroff', '-prompt'])
-	// Util.spawn(['gnome-session-quit', '--power-off'])
 	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Shutdown'])
 }
 
 function _lockScreen() {
-	// Util.spawn(['loginctl', 'lock-session'])
 	Util.spawn(['dbus-send', '--type=method_call', '--dest=org.gnome.ScreenSaver', '/org/gnome/ScreenSaver', 'org.gnome.ScreenSaver.Lock'])
 }
 
 function _logOut() {
-	// Util.spawn(['gnome-session-quit'])
-	// Util.spawn(['gnome-session-quit', '--logout'])
 	Util.spawn(['dbus-send', '--session', '--type=method_call', '--dest=org.gnome.SessionManager', '/org/gnome/SessionManager', 'org.gnome.SessionManager.Logout', 'uint32:0'])
 }
 


### PR DESCRIPTION
Replaces non-interactive immediate actions for the restart, shutdown, lock screen and logout menu options with interactive `dbus-send` commands that trigger the standard user-confirmation dialogs for these functions (except lock screen function). 

Why: The usual UI expectation in macOS, GNOME or most other full desktop environments is for Restart, Shutdown and Logout commands to trigger the display of a confirmation dialog, to allow the user to cancel an accidental triggering of the command that may interrupt the use of the desktop in an unwanted way. 

I can confirm that both the current Restart (`systemctl reboot`) and Shut Down (`systemctl poweroff -prompt`) menu options take immediate action without producing any prompts on Ubuntu 22.04. These replacement commands will fix that. 

Two menu option labels (Restart, Shutdown) are changed here to add ellipsis "..." to show that the command will now open a window/dialog or has a second step of some kind before it takes action. 

Some alternative commands are left here in commented-out lines, which should bring up the same interactive user-confirmation dialogs. These use CLI arguments to the `gnome-session-quit` command instead of `dbus-send`. They seem to do exactly the same thing, just in a different way. (There is no `gnome-session-quit` CLI option for locking the screen, only for restart, shutdown and logout.) 

The original commands that implemented the restart, shutdown, lock screen and logout functions are also left here in commented-out lines for reference. 

The full `dbus-send` (and alternatively the `gnome-session-quit`) commands are: 

Restart...: 
gnome-session-quit --reboot
dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Reboot

Shut Down...:
gnome-session-quit --power-off
dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Shutdown

Lock screen:
dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock

Log Out...:
gnome-session-quit --logout (seems to work the same way with or without the "--logout" option)
dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Logout uint32:0

References: 

https://itectec.com/ubuntu/ubuntu-reboot-without-sudoer-privileges/
https://github.com/collinss/Session-Manager/blob/master/commands
https://gitlab.gnome.org/GNOME/gnome-session/-/blob/main/gnome-session/org.gnome.SessionManager.xml