### PR TITLE
Use System Status Icon style class

### DIFF
--- a/PrefsLib/adw.js
+++ b/PrefsLib/adw.js
@@ -360,6 +360,22 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
         });
 
         activitiesButtonVisiblityRow.add_suffix(activitiesButtonVisiblitySwitch);
+        
+         // Icon Shadow Visibility
+        const iconShadowVisibilityRow = new Adw.ActionRow({
+            title: _('Hide Icon Shadow'),
+        });
+
+        const iconShadowRowVisiblitySwitch = new Gtk.Switch({
+            valign: Gtk.Align.CENTER,
+            active: this._settings.get_boolean('hide-icon-shadow'),
+        });
+
+        iconShadowRowVisiblitySwitch.connect('notify::active', widget => {
+            this._settings.set_boolean('hide-icon-shadow', widget.get_active());
+        });
+
+        iconShadowVisibilityRow.add_suffix(iconShadowRowVisiblitySwitch);
 
         // Pref Group
         prefGroup1.add(menuButtonIconClickTypeRow);
@@ -374,6 +390,7 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
         prefGroup2.add(softwareCentreOptionRow);
 
         prefGroup3.add(activitiesButtonVisiblityRow);
+        prefGroup3.add(iconShadowVisibilityRow);
 
         this.add(prefGroup1);
         this.add(prefGroup2);

--- a/extension.js
+++ b/extension.js
@@ -30,12 +30,17 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
         // Icon
         this.icon = new St.Icon({
-            style_class: 'system-status-icon menu-button',
+        //style_class: 'system-status-icon',
+           style_class: 'menu-button',
+           //style_class: 'menu-button',
         });
+        
+        this._settings.connectObject('changed::hide-icon-shadow', () => this.hideIconShadow(), this);
         this._settings.connectObject('changed::menu-button-icon-image', () => this.setIconImage(), this);
         this._settings.connectObject('changed::symbolic-icon', () => this.setIconImage(), this);
         this._settings.connectObject('changed::menu-button-icon-size', () => this.setIconSize(), this);
-
+	
+	this.hideIconShadow()
         this.setIconImage();
         this.setIconSize();
         this.add_child(this.icon);
@@ -71,7 +76,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         if (showSoftwareCenter)
-            this._addItem(new MenuItem(_('Software Center...'), () => this._openSoftwareCenter()));
+            this._addItem(new MenuItem(_('Software Center'), () => this._openSoftwareCenter()));
 
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));
@@ -207,6 +212,16 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         const iconSize = this._settings.get_int('menu-button-icon-size');
         this.icon.icon_size = iconSize;
     }
+    
+    hideIconShadow() {
+    	const IconShadow = this._settings.get_boolean('hide-icon-shadow');
+    	
+        if(!IconShadow){
+            this.icon.add_style_class_name('system-status-icon'); 
+        } else {
+            this.icon.remove_style_class_name('system-status-icon');
+        }
+    }
 });
 
 export default class LogoMenu extends Extension {
@@ -219,7 +234,7 @@ export default class LogoMenu extends Extension {
         this._setActivitiesVisibility();
 
         const indicator = new MenuButton(this);
-        Main.panel.addToStatusArea('LogoMenu', indicator, 0, 'left');
+        Main.panel.addToStatusArea('LogoMenu', indicator, 1, 'left');
     }
 
     disable() {

--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
         // Icon
         this.icon = new St.Icon({
-            style_class: 'menu-button',
+            style_class: 'system-status-icon menu-button',
         });
         this._settings.connectObject('changed::menu-button-icon-image', () => this.setIconImage(), this);
         this._settings.connectObject('changed::symbolic-icon', () => this.setIconImage(), this);

--- a/extension.js
+++ b/extension.js
@@ -30,9 +30,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
         // Icon
         this.icon = new St.Icon({
-        //style_class: 'system-status-icon',
            style_class: 'menu-button',
-           //style_class: 'menu-button',
         });
         
         this._settings.connectObject('changed::hide-icon-shadow', () => this.hideIconShadow(), this);

--- a/extension.js
+++ b/extension.js
@@ -74,7 +74,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this._addItem(new PopupMenu.PopupSeparatorMenuItem());
 
         if (showSoftwareCenter)
-            this._addItem(new MenuItem(_('Software Center'), () => this._openSoftwareCenter()));
+            this._addItem(new MenuItem(_('Software Center...'), () => this._openSoftwareCenter()));
 
         this._addItem(new MenuItem(_('System Monitor'), () => this._openSystemMonitor()));
         this._addItem(new MenuItem(_('Terminal'), () => this._openTerminal()));

--- a/extension.js
+++ b/extension.js
@@ -232,7 +232,7 @@ export default class LogoMenu extends Extension {
         this._setActivitiesVisibility();
 
         const indicator = new MenuButton(this);
-        Main.panel.addToStatusArea('LogoMenu', indicator, 1, 'left');
+        Main.panel.addToStatusArea('LogoMenu', indicator, 0, 'left');
     }
 
     disable() {

--- a/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
@@ -68,6 +68,13 @@
       <summary>Toggle visibility of the top panel activities button</summary>
       <description>Toggle visibility of the top panel activities button.</description>
     </key>
+    
+    <key type="b" name="hide-icon-shadow">
+      <default>true</default>
+      <summary>Toggle visibility of the top panel icon's shadow </summary>
+      <description>Toggle visibility of the top panel icon's shadow.</description>
+    </key>
+
 
     <key type="b" name="symbolic-icon">
       <default>true</default>

--- a/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
@@ -70,7 +70,7 @@
     </key>
     
     <key type="b" name="hide-icon-shadow">
-      <default>true</default>
+      <default>false</default>
       <summary>Toggle visibility of the top panel icon's shadow </summary>
       <description>Toggle visibility of the top panel icon's shadow.</description>
     </key>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,7 +1,9 @@
 .menu-button {
-	margin: 1px;
+	margin: 1px !important;
+ 	padding: 0px !important;
 }
 
 .menu-button-hover {
-	margin: 1px;
+	margin: 1px !important;
+	padding: 0px !important;
 }


### PR DESCRIPTION
# This is a visual thing that I ran into that this PR fixes

I use a transparent panel and all panel icons use the same `system-status-icon` class. Other extensions override this class to provide a nice shadow to help it stand out more against lighter backgrounds. I still use the `menu-button` class to fix the excessive padding. I'm not sure if this should be the default, but with a solid black panel nothing looks different.


![Screenshot from 2023-10-24 17-55-34](https://github.com/Aryan20/Logomenu/assets/103920890/d601b827-3872-4e81-9819-5ee73618c433)
