### PR TITLE
Add Switch User... Option to Menu

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,7 @@ class LogoMenuMenuButton extends PanelMenu.Button {
                 this._addItem(new MenuItem(_('Lock Screen'), () => this._lockScreen()));
 
             this._addItem(new MenuItem(_('Log Out...'), () => this._logOut()));
+	    this._addItem(new MenuItem(_('Switch User...'), () => this._switchUser()));
         } else if (!showPowerOptions && showLockScreen) {
             this._addItem(new PopupMenu.PopupSeparatorMenuItem());
             this._addItem(new MenuItem(_('Lock Screen'), () => this._lockScreen()));
@@ -155,6 +156,10 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
     _logOut() {
         Util.spawn(['gnome-session-quit', '--logout']);
+    }
+
+    _switchUser() {
+        Util.trySpawnCommandLine('/usr/bin/gdmflexiserver');
     }
 
     _showAppGrid() {


### PR DESCRIPTION
If the user has showPowerOptions set to true then there should also be an option to just switch users (IE go to the GDM Greeter without logging the current user out).

I added the menu item and a function to do that.