### PR TITLE
feat: add windows logo

### DIFF
--- a/Resources/windows-logo-symbolic.svg
+++ b/Resources/windows-logo-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 496 496"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="windows-logo-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   width="496"
+   height="496"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.91902125"
+     inkscape:cx="206.19763"
+     inkscape:cy="231.76831"
+     inkscape:window-width="1920"
+     inkscape:window-height="1008"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M 0,0 H 235.1294 V 235.0277 H 0 Z M 260.8706,0 H 496 V 235.0277 H 260.8706 Z M 0,260.8706 H 235.1294 V 496 H 0 Z m 260.8706,0 H 496 V 496 H 260.8706"
+     id="path1"
+     style="fill:#cccccc;fill-opacity:1;stroke-width:0.101744" />
+</svg>

--- a/constants.js
+++ b/constants.js
@@ -31,6 +31,7 @@ export const SymbolicDistroIcons = [
     {PATH: '/Resources/steam-deck-logo-symbolic.svg'},
     {PATH: '/Resources/ublue-logo-symbolic.svg'},
     {PATH: '/Resources/centos-logo-symbolic.svg'},
+    {PATH: '/Resources/windows-logo-symbolic.svg'},
 ];
 
 export const ColouredDistroIcons = [


### PR DESCRIPTION
SVG taken from https://commons.wikimedia.org/wiki/File:Windows_logo_-_2021_(Black).svg and edited.
According to Wikipedia:
> This logo image consists only of simple geometric shapes or text. It does not meet the [threshold of originality](https://commons.wikimedia.org/wiki/Commons:Threshold_of_originality) needed for copyright protection, and is therefore in the [public domain](https://en.wikipedia.org/wiki/public_domain).

This is for the LOLs.