### PR TITLE
extension: add support for menu button label

### DIFF
--- a/PrefsLib/adw.js
+++ b/PrefsLib/adw.js
@@ -213,11 +213,28 @@ export const LogoMenuIconsPage = GObject.registerClass(class LogoMenuIconsWidget
         customIconSelectionRow.add_suffix(customIconButton);
         customIconRow.add_row(customIconSelectionRow);
 
+        // Show Button Label toggle
+        const showLabelRow = new Adw.SwitchRow({
+            title: _('Show Button Label'),
+            subtitle: _('Display a text label next to the icon in the top panel.'),
+        });
+        this._settings.bind('show-menu-button-label', showLabelRow,
+            'active', Gio.SettingsBindFlags.DEFAULT);
+
+        // Button Label text entry
+        const labelTextRow = new Adw.EntryRow({
+            title: _('Button Label Text'),
+        });
+        this._settings.bind('menu-button-label-text', labelTextRow,
+            'text', Gio.SettingsBindFlags.DEFAULT);
+
         // iconGroup
         symbolicIconGroup.add(symbolicIconsRow);
         colouredIconGroup.add(colouredIconsRow);
         iconSettingsGroup.add(customIconRow);
         iconSettingsGroup.add(menuButtonIconSizeRow);
+        iconSettingsGroup.add(showLabelRow);
+        iconSettingsGroup.add(labelTextRow);
 
         this.add(symbolicIconGroup);
         this.add(colouredIconGroup);

--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,4 @@
+import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -34,18 +35,33 @@ class LogoMenuMenuButton extends PanelMenu.Button {
         this.icon = new St.Icon({
            style_class: 'menu-button',
         });
-        
+
+        this.label = new St.Label({
+            text: '',
+            y_align: Clutter.ActorAlign.CENTER,
+            style_class: 'menu-button-label',
+        });
+
+        this._buttonBox = new St.BoxLayout({
+            style_class: 'panel-status-menu-box',
+        });
+        this._buttonBox.add_child(this.icon);
+        this._buttonBox.add_child(this.label);
+
         this._settings.connectObject('changed::hide-icon-shadow', () => this.hideIconShadow(), this);
         this._settings.connectObject('changed::menu-button-icon-image', () => this.setIconImage(), this);
         this._settings.connectObject('changed::symbolic-icon', () => this.setIconImage(), this);
         this._settings.connectObject('changed::use-custom-icon', () => this.setIconImage(), this);
         this._settings.connectObject('changed::custom-icon-path', () => this.setIconImage(), this);
         this._settings.connectObject('changed::menu-button-icon-size', () => this.setIconSize(), this);
-	
-	this.hideIconShadow();
+        this._settings.connectObject('changed::show-menu-button-label', () => this._updateLabel(), this);
+        this._settings.connectObject('changed::menu-button-label-text', () => this._updateLabel(), this);
+
+        this.hideIconShadow();
         this.setIconImage();
         this.setIconSize();
-        this.add_child(this.icon);
+        this._updateLabel();
+        this.add_child(this._buttonBox);
 
         // Menu
         this._settings.connectObject('changed::hide-softwarecentre', () => this._displayMenuItems(), this);
@@ -62,6 +78,13 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
     _addItem(item) {
         this.menu.addMenuItem(item);
+    }
+
+    _updateLabel() {
+        const enabled = this._settings.get_boolean('show-menu-button-label');
+        const text = this._settings.get_string('menu-button-label-text') || '';
+        this.label.set_text(text);
+        this.label.visible = enabled && text.length > 0;
     }
 
     _displayMenuItems() {

--- a/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
@@ -99,6 +99,18 @@
       <summary>Menu System Monitor</summary>
       <description>Change the Menu System Monitor.</description>
     </key>
+
+    <key type="b" name="show-menu-button-label">
+      <default>false</default>
+      <summary>Show text label next to the menu button icon</summary>
+      <description>Whether a custom text label is shown next to the icon in the top panel.</description>
+    </key>
+
+    <key type="s" name="menu-button-label-text">
+      <default>""</default>
+      <summary>Menu button label text</summary>
+      <description>Text displayed next to the menu button icon when the label is enabled.</description>
+    </key>
   </schema>
 
 </schemalist>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -7,3 +7,7 @@
 	margin: 1px !important;
 	padding: 0px !important;
 }
+
+.menu-button-label {
+	padding-left: 4px;
+}


### PR DESCRIPTION
### feat: add support for menu button label

Added the ability to show a customizable text label next to the menu button icon in the top panel.

- New toggle: "Show Button Label"
- New setting: "Button Label Text"
- Properly integrated with existing settings and UI

Closes #83