### PR TITLE
Feature: A mouse key can be assigned to open AppGrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /logomenu@aryan_k.shell-extension.zip
 /po.sh
+
+*test*
+*original-copy*
+*gschemas.compiled

--- a/PrefsLib/adw.js
+++ b/PrefsLib/adw.js
@@ -257,16 +257,50 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
         const menuButtonIconClickTypeCombo = new Gtk.ComboBoxText({
             valign: Gtk.Align.CENTER,
         });
+        menuButtonIconClickTypeCombo.append('0', _('Disabled '));
         menuButtonIconClickTypeCombo.append('1', _('Left Click '));
         menuButtonIconClickTypeCombo.append('2', _('Middle Click '));
         menuButtonIconClickTypeCombo.append('3', _('Right Click '));
         menuButtonIconClickTypeCombo.set_active_id(clickType.toString());
 
+        // App Grid click type
+
+        const appGridClickType = this._settings.get_int('menu-button-icon-appgrid-click-type');
+        const menuButtonAppGridClickTypeRow = new Adw.ActionRow({
+            title: _('Icon Click Type to open App Grid'),
+        });
+
+        const menuButtonAppGridClickTypeCombo = new Gtk.ComboBoxText({
+            valign: Gtk.Align.CENTER,
+        });
+        menuButtonAppGridClickTypeCombo.append('0', _('Disabled'));
+        menuButtonAppGridClickTypeCombo.append('1', _('Left Click'));
+        menuButtonAppGridClickTypeCombo.append('2', _('Middle Click'));
+        menuButtonAppGridClickTypeCombo.append('3', _('Right Click'));
+        menuButtonAppGridClickTypeCombo.set_active_id(appGridClickType.toString());
+
+        // Intercepts conflicts: If an option matches, set the other to 'Disabled' (0)
+
         menuButtonIconClickTypeCombo.connect('changed', () => {
-            this._settings.set_int('menu-button-icon-click-type', parseInt(menuButtonIconClickTypeCombo.get_active_id()));
+            const newOverviewVal = menuButtonIconClickTypeCombo.get_active_id();
+            if (newOverviewVal !== '0' && newOverviewVal === menuButtonAppGridClickTypeCombo.get_active_id()) {
+                menuButtonAppGridClickTypeCombo.set_active_id('0');
+                this._settings.set_int('menu-button-icon-appgrid-click-type', 0);
+            }
+            this._settings.set_int('menu-button-icon-click-type', parseInt(newOverviewVal));
+        });
+
+        menuButtonAppGridClickTypeCombo.connect('changed', () => {
+            const newAppGridVal = menuButtonAppGridClickTypeCombo.get_active_id();
+            if (newAppGridVal !== '0' && newAppGridVal === menuButtonIconClickTypeCombo.get_active_id()) {
+                menuButtonIconClickTypeCombo.set_active_id('0');
+                this._settings.set_int('menu-button-icon-click-type', 0);
+            }
+            this._settings.set_int('menu-button-icon-appgrid-click-type', parseInt(newAppGridVal));
         });
 
         menuButtonIconClickTypeRow.add_suffix(menuButtonIconClickTypeCombo);
+        menuButtonAppGridClickTypeRow.add_suffix(menuButtonAppGridClickTypeCombo);
 
         // Extensions application choice
 
@@ -443,6 +477,7 @@ export const LogoMenuOptionsPage = GObject.registerClass(class LogoMenuOptionsWi
 
         // Pref Group
         prefGroup1.add(menuButtonIconClickTypeRow);
+        prefGroup1.add(menuButtonAppGridClickTypeRow);
         prefGroup1.add(extensionsAppRow);
         prefGroup1.add(menuButtonTerminalRow);
         prefGroup1.add(softwareCentreRow);

--- a/extension.js
+++ b/extension.js
@@ -116,11 +116,17 @@ class LogoMenuMenuButton extends PanelMenu.Button {
 
     vfunc_event(event) {
         if (event.type() === Clutter.EventType.BUTTON_PRESS) {
-            // left click === 1, middle click === 2, right click === 3
-            const clickType = this._settings.get_int('menu-button-icon-click-type');
-            if (event.get_button() === clickType) {
+            const buttonPressed = event.get_button();
+            // disabled === 0, left click === 1, middle click === 2, right click === 3
+            const overviewClickType = this._settings.get_int('menu-button-icon-click-type');
+            const appGridClickType = this._settings.get_int('menu-button-icon-appgrid-click-type');
+
+            if (buttonPressed === overviewClickType) {
                 this.menu.close();
                 Main.overview.toggle();
+            } else if (buttonPressed === appGridClickType) {
+                this.menu.close();
+                this._showAppGrid();
             } else {
                 this.menu?.toggle();
             }

--- a/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.logo-menu.gschema.xml
@@ -21,6 +21,12 @@
       <description>Change the Menu Button click type to open Activity.</description>
     </key>
 
+    <key type="i" name="menu-button-icon-appgrid-click-type">
+      <default>0</default>
+      <summary>Menu Button click type to open App Grid</summary>
+      <description>Change the Menu Button click type to open App Grid.</description>
+    </key>
+
     <key type="s" name="menu-button-extensions-app">
       <default>"org.gnome.Extensions.desktop"</default>
       <summary>Preffered Extensions app</summary>


### PR DESCRIPTION
Added an option that lets users assign a mouse key that will open the GNOME App Grid menu by clicking the logo icon. It is disabled by default, and does not conflict the already existing 'open Activities' option.

#### Key Details:
- Heavily based on the existing logic used for "Icon Click Type to open Activities";
- Adds a "Disabled" state option (`0 === Disabled`);
- If a specific mouse button is already assigned to the Activities option and the user selects it for the App Grid, the Activities option automatically switches to Disabled (and vice versa) to prevent conflicts;
- The implementation complements the already existing structure, so active maintainers can easily add to/modify if needed.
#### Preview:
<img width="626" height="569" alt="preview" src="https://github.com/user-attachments/assets/48f1778b-9c13-4775-946a-59fd9937a7d5" />